### PR TITLE
alpine: Add more packages

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,7 +1,16 @@
 ARG TAG=latest
 FROM docker.io/alpine:${TAG}
 
-RUN apk add git sudo
+RUN apk add \
+      bash \
+      clang \
+      curl \
+      gcc \
+      git \
+      jq \
+      make \
+      sudo \
+      wget
 RUN adduser -D runner
 RUN echo "runner ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 


### PR DESCRIPTION
To align closer with the default set of software available on runners, include also:

* bash
* clang
* curl
* gcc
* jq
* make
* wget